### PR TITLE
firefox: replace overrideAttrs with override

### DIFF
--- a/packages/overlay.nix
+++ b/packages/overlay.nix
@@ -9,7 +9,7 @@ final: prev: {
     '';
   }); */
 
-  firefox = prev.firefox.overrideAttrs (p: {
+  firefox = prev.firefox.override (p: {
     extraPrefsFiles = [ "${final.widevine-installer}/conf/gmpwidevine.js" ];
   });
 


### PR DESCRIPTION
`extraPrefsFiles` is an [overridable input](https://github.com/NixOS/nixpkgs/blob/4cba8b53da471aea2ab2b0c1f30a81e7c451f4b6/pkgs/applications/networking/browsers/firefox/wrapper.nix#L48) to the `firefox` wrapper -- it should be modified with `override` instead of `overrideAttrs`. Confirmed working on my system -- the preferences do not appear in `about:config` with `overrideAttrs`, but do using just `override`.

Thanks for the repo!